### PR TITLE
Support for AngelCode BMFont format

### DIFF
--- a/src/fontrender.h
+++ b/src/fontrender.h
@@ -67,12 +67,14 @@ private:
         int     m_size;
         Metric  m_metric;
         int     m_style;
+        QFont   m_qfont;
         QList<const packedImage*> m_glyphLst;
         QList<kerningPair> m_kerningList;
     };
 
     bool outputFNT(const QList<FontRec>& fontLst, const QImage& texture);
     bool outputXML(const QList<FontRec>& fontLst, const QImage& texture);
+    bool outputBMFont(const QList<FontRec>& fontLst, const QImage& texture);
     unsigned int qchar2ui(QChar ch);
     QImage texture;
     QList<QImage> glyphs;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1058,6 +1058,11 @@
               <string>XML</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>BMFont</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
Hi,

This pull request adds an ability to export bitmap fonts to the original AngelCode BMFont file format. Please review and apply it if you wish to support this format or just want to make a BMFont killa;)

Since BMFont doesn't support multiple fonts per .fnt file, they are saved to separate .fnt files using a single shared texture image e.g. myfont_0.fnt, myfont_1.fnt, myfont_2.fnt, myfont.png.

TIA!
